### PR TITLE
Add cmdlet Debug-IISProcess

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -70,6 +70,8 @@ Here's the about text showing all cmdlets. Of course, all cmdlets have detailed 
 	        Open-LastIntelliTraceRecording                  When you stop debugging, your current IntelliTrace log disappears. This
 	                                                        cmdlet fixes that by opening the last log you produced so you can post-mortem
 	                                                        look at your debugging session.
+															
+			Debug-IISProcess								Attaches Visual Studio to the w3wp.exe process associated with a given application pool name.
 	
 	SEE ALSO
 	    Online help and updates: http://www.wintellect.com/devcenter/author/jrobbins

--- a/WintellectVSCmdlets.psm1
+++ b/WintellectVSCmdlets.psm1
@@ -39,6 +39,38 @@ Export-ModuleMember -function Get-Threads
 ###############################################################################
 
 ###############################################################################
+function Debug-IISProcess
+{
+<#
+.SYNOPSIS
+Attaches Visual Studio to the w3wp.exe process associated with a given application pool name.
+#>
+
+    param (
+        [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [String]$AppPoolName
+    ) 
+
+    $process = Get-WmiObject -Namespace "root/cimv2" -Query "SELECT * FROM Win32_Process where Name = 'w3wp.exe'" |  Where-Object { $_.CommandLine -match "-ap `"$AppPoolName`"" } 
+
+    if ($process -eq $null) {
+        Write-Host "Could not find w3wp.exe process associated with app pool '$AppPoolName'."
+    } else {
+        Write-Host "Attaching to w3wp.exe process associated with app pool '$AppPoolName'."
+        
+        foreach ($proc in $dte.Debugger.LocalProcesses) {
+            if ($proc.ProcessID -eq $process.ProcessId){
+                $proc.Attach()
+                break
+            }
+        }    
+    }
+}
+
+Export-ModuleMember -function Debug-IISProcess
+###############################################################################
+
+###############################################################################
 function Get-Breakpoints
 {
 <#


### PR DESCRIPTION
I've used Debug-IISProcess a lot over the last few years. I've personally saved a lot of time by only having to type this command out each time I want to attach VS to an app pool.

Granted there might be VS extensions that do the same thing, but hey, who doesn't love a bit of Powershell automation now and again? :)